### PR TITLE
기준 로그인 방식에 따른 조건부 로그아웃 기능 구현

### DIFF
--- a/app/src/main/java/com/example/food_recipe/login/LoginActivity.java
+++ b/app/src/main/java/com/example/food_recipe/login/LoginActivity.java
@@ -1,5 +1,6 @@
 package com.example.food_recipe.login;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
@@ -211,4 +212,9 @@ public class LoginActivity extends AppCompatActivity implements LoginContract.Vi
         return et != null && et.getText() != null ? et.getText().toString() : "";
     }
 
+    // (새로추가됨) LoginContract.View 인터페이스의 getContext() 메소드 구현
+    @Override
+    public Context getContext() {
+        return this; // Activity Context 반환
+    }
 }

--- a/app/src/main/java/com/example/food_recipe/login/LoginContract.java
+++ b/app/src/main/java/com/example/food_recipe/login/LoginContract.java
@@ -1,4 +1,6 @@
 package com.example.food_recipe.login;
+
+import android.content.Context; // (새로추가됨) Context 사용을 위해 import
 import com.google.firebase.auth.FirebaseUser;     // 👉 추가
 import java.util.List;
 
@@ -29,6 +31,9 @@ public interface LoginContract {
         // ✅ 추가: 로그인 성공 시 AutoLogin 처리까지 View가 담당
         // - Presenter는 "성공했다"만 알리고, 실제 AutoLoginManager 호출은 View에서 함
         void onLoginSuccess(boolean autoLoginChecked);
+
+        // (새로추가됨) Presenter가 Context를 요청할 때 호출될 메서드
+        Context getContext();
     }
 
 

--- a/app/src/main/java/com/example/food_recipe/main/MainActivity.java
+++ b/app/src/main/java/com/example/food_recipe/main/MainActivity.java
@@ -1,5 +1,6 @@
 package com.example.food_recipe.main;
 
+import android.content.Context; // (새로추가됨) Context 사용을 위해 import
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
@@ -25,6 +26,7 @@ import com.google.android.material.appbar.MaterialToolbar;
 public class MainActivity extends AppCompatActivity implements MainContract.View {
 
     private MainContract.Presenter presenter;
+    private Menu optionsMenu; // (새로추가됨) 옵션 메뉴 객체를 저장하기 위한 멤버 변수
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -96,7 +98,7 @@ public class MainActivity extends AppCompatActivity implements MainContract.View
     @Override
     protected void onStart() {
         super.onStart();
-        presenter.start();
+        presenter.start(); // Presenter에게 시작을 알림 (로그인 상태 확인 등)
     }
 
     @Override
@@ -110,6 +112,7 @@ public class MainActivity extends AppCompatActivity implements MainContract.View
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.main_toolbar_menu, menu);
+        this.optionsMenu = menu; // (새로추가됨) 메뉴 객체 저장
 
         // --- 프로필 아이콘 클릭 리스너 설정 추가 ---
         MenuItem profileItem = menu.findItem(R.id.action_profile);
@@ -122,7 +125,11 @@ public class MainActivity extends AppCompatActivity implements MainContract.View
             }
         }
         // --- 여기까지 추가 ---
-
+        // (새로추가됨) 초기 presenter 상태에 따라 로그아웃 버튼 활성화 여부 반영 (선택적이지만 권장)
+        // 이 시점에는 presenter가 아직 start()를 호출하지 않았을 수 있으므로,
+        // presenter.start() 완료 후 또는 로그인 상태가 명확해진 후 호출하는 것이 더 정확할 수 있습니다.
+        // presenter.start() 내부의 onLoggedIn 콜백에서 setLogoutEnabled(true)가 호출되므로,
+        // 여기서 별도로 호출할 필요는 없을 수 있습니다. 또는 onPrepareOptionsMenu에서 처리할 수도 있습니다.
         return true;
     }
 
@@ -132,10 +139,11 @@ public class MainActivity extends AppCompatActivity implements MainContract.View
         if (id == R.id.action_profile) {
             // 이 부분은 actionView의 리스너에서 이미 처리하므로, 여기서는 호출되지 않거나
             // 중복될 수 있습니다. 필요에 따라 주석 처리하거나 다른 방식으로 관리할 수 있습니다.
-            // Toast.makeText(this, "프로필 화면(추후 연결) - onOptionsItemSelected", Toast.LENGTH_SHORT).show();
-            return true; 
+            return true;
         } else if (id == R.id.action_logout) {
-            presenter.onLogoutClicked();
+            if (item.isEnabled()) { // (새로추가됨) 버튼이 활성화되어 있을 때만 Presenter 호출
+                presenter.onLogoutClicked();
+            }
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -157,6 +165,28 @@ public class MainActivity extends AppCompatActivity implements MainContract.View
 
     @Override
     public void setLogoutEnabled(boolean enabled) {
-        // 필요 시 메뉴 enable/disable 구현
+        // (변경된부분) 실제 로그아웃 메뉴 아이템 활성화/비활성화
+        if (optionsMenu != null) {
+            MenuItem logoutItem = optionsMenu.findItem(R.id.action_logout);
+            if (logoutItem != null) {
+                logoutItem.setEnabled(enabled);
+                // (선택적) 아이콘의 알파값을 변경하여 시각적 피드백 강화
+                // Drawable icon = logoutItem.getIcon();
+                // if (icon != null) {
+                //    icon.setAlpha(enabled ? 255 : 130);
+                // }
+                android.util.Log.d("MainActivity", "setLogoutEnabled: Logout menu item " + (enabled ? "enabled" : "disabled"));
+            } else {
+                android.util.Log.w("MainActivity", "setLogoutEnabled: Logout menu item (R.id.action_logout) not found.");
+            }
+        } else {
+            android.util.Log.w("MainActivity", "setLogoutEnabled: OptionsMenu is null. Cannot enable/disable logout menu item.");
+        }
+    }
+
+    // (새로추가됨) MainContract.View 인터페이스의 getContext() 메소드 구현
+    @Override
+    public Context getContext() {
+        return this; // Activity Context 반환
     }
 }

--- a/app/src/main/java/com/example/food_recipe/main/MainContract.java
+++ b/app/src/main/java/com/example/food_recipe/main/MainContract.java
@@ -1,5 +1,7 @@
 package com.example.food_recipe.main;
 
+import android.content.Context;
+
 /**
  * MVP 패턴의 각 컴포넌트(Model, View, Presenter)가 무엇을 해야 하는지 정의하는 '계약서'입니다.
  * 이 파일을 보면 Main 화면의 전체적인 구조와 기능을 한눈에 파악할 수 있습니다.
@@ -21,6 +23,9 @@ public interface MainContract {
 
         /** Presenter가 "로그아웃 버튼 활성화/비활성화 해"라고 호출할 메서드 */
         void setLogoutEnabled(boolean enabled);
+
+        // (새로추가됨) Presenter가 Context를 요청할 때 호출될 메서드 (AutoLoginManager 사용 위함)
+        Context getContext();
     }
 
     /**
@@ -58,8 +63,12 @@ public interface MainContract {
             void onError(Exception e); // 작업 실패 시 호출
         }
 
-        /** Presenter가 "로그아웃 시켜줘"라고 호출할 메서드 */
-        void logout(LogoutCallback cb);
+        /**
+         * Presenter가 "로그아웃 시켜줘"라고 호출할 메서드 (변경된부분)
+         * @param loginProvider 현재 로그인된 방식 (예: AutoLoginManager.PROVIDER_EMAIL, AutoLoginManager.PROVIDER_GOOGLE) (새로추가됨)
+         * @param cb 작업 완료 후 호출될 콜백
+         */
+        void logout(String loginProvider, LogoutCallback cb); // (변경된부분) loginProvider 파라미터 명시적 추가
 
         /**
          * 로그인 상태 확인 작업이 끝났을 때, Presenter에게 결과를 알려주기 위한 콜백 인터페이스


### PR DESCRIPTION
기존에서 로그로 확인했을때 로그아웃하면 그냥 한꺼번에 했음
그래서 나누어서 로그아웃을 분리함

구글 로그인 시 Firebase와 Google 계정 동시 로그아웃
이메일 로그인 시 Firebase만 로그아웃하도록 분리