### PR TITLE
기준 하단네비게이션바 3탭 화면전환

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,4 +63,7 @@ dependencies {
     implementation(libs.navigation.fragment)
     implementation(libs.navigation.ui)
     implementation(libs.play.services.auth)
+    implementation(libs.coordinatorlayout)
+
+    
 }

--- a/app/src/main/java/com/example/food_recipe/favorites/FavoritesFragment.java
+++ b/app/src/main/java/com/example/food_recipe/favorites/FavoritesFragment.java
@@ -1,0 +1,20 @@
+package com.example.food_recipe.favorites;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import com.example.food_recipe.R;
+
+public class FavoritesFragment extends Fragment {
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        // fragment_favorites.xml 레이아웃을 인플레이트하여 반환합니다.
+        return inflater.inflate(R.layout.fragment_favorites, container, false);
+    }
+}

--- a/app/src/main/java/com/example/food_recipe/main/MainActivity.java
+++ b/app/src/main/java/com/example/food_recipe/main/MainActivity.java
@@ -5,141 +5,147 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.graphics.Insets;
-import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
-import androidx.fragment.app.Fragment;
+// [핵심 Import] Jetpack Navigation Component의 핵심 클래스들입니다.
+import androidx.navigation.NavController;
+import androidx.navigation.fragment.NavHostFragment;
+import androidx.navigation.ui.NavigationUI;
 
 import com.example.food_recipe.R;
-import com.example.food_recipe.home.HomeFragment;
 import com.example.food_recipe.login.LoginActivity;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.appbar.MaterialToolbar;
 
+/**
+ * MainActivity는 앱의 메인 화면을 담당하는 유일한 액티비티입니다.
+ * 이 액티비티는 상단 툴바, 하단 네비게이션 바, 그리고 그 사이의 프래그먼트 콘텐츠 영역을 포함합니다.
+ * MVP 패턴의 'View' 역할을 수행하며, 사용자 입력을 Presenter에 전달하고 Presenter의 지시에 따라 UI를 업데이트합니다.
+ */
 public class MainActivity extends AppCompatActivity implements MainContract.View {
 
+    // MVP 패턴의 Presenter 인터페이스입니다. View는 Presenter를 통해 비즈니스 로직을 처리합니다.
     private MainContract.Presenter presenter;
+    // 툴바의 메뉴 아이템(예: 로그아웃 버튼)에 접근하기 위한 변수입니다.
     private Menu optionsMenu;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        // [UI 설정] Edge-to-Edge UI를 구현합니다.
+        // 이 코드는 앱 콘텐츠가 상태바나 네비게이션바 영역 뒤까지 확장될 수 있도록 허용하여
+        // 더 현대적이고 몰입감 있는 UI를 제공합니다.
         WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
-
         WindowInsetsControllerCompat windowInsetsController = WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
         if (windowInsetsController != null) {
+            // 상태바 아이콘들을 어둡게 설정합니다. (배경이 밝을 경우 사용)
+            // 만약 배경이 어둡다면 false로 설정해야 아이콘이 흰색으로 보입니다.
             windowInsetsController.setAppearanceLightStatusBars(false);
         }
 
+        // activity_main.xml 레이아웃 파일을 화면에 표시합니다.
         setContentView(R.layout.activity_main);
 
+        // [MVP 초기화] Presenter를 생성하고 View(자기 자신)를 연결합니다.
         presenter = new MainPresenter(this);
         presenter.attach(this);
 
+        // [Toolbar 설정] activity_main.xml에 있는 툴바를 찾아 액션바로 설정합니다.
         MaterialToolbar toolbar = findViewById(R.id.main_toolbar);
         setSupportActionBar(toolbar);
 
+
+        // =================================================================
+        // [Jetpack Navigation Component 설정] - 모든 화면 전환 로직의 핵심
+        // =================================================================
+
+        // 1. NavHostFragment 가져오기
+        // activity_main.xml에 정의된 FragmentContainerView(ID: nav_host_fragment)를 찾습니다.
+        // 이 NavHostFragment는 모든 프래그먼트들이 교체되며 보여지는 '무대' 역할을 합니다.
+        NavHostFragment navHostFragment = (NavHostFragment) getSupportFragmentManager()
+                .findFragmentById(R.id.nav_host_fragment);
+
+        // 2. NavController 가져오기
+        // 실제 화면 전환을 담당하는 '총 감독'인 NavController를 NavHostFragment로부터 얻습니다.
+        // 앞으로 모든 화면 이동 명령은 이 NavController를 통해 이루어집니다.
+        NavController navController = navHostFragment.getNavController();
+
+        // 3. BottomNavigationView와 NavController 자동 연결
+        // activity_main.xml의 BottomNavigationView(ID: main_bottom_nav)를 찾습니다.
         BottomNavigationView bottomNav = findViewById(R.id.main_bottom_nav);
-        View mainContainer = findViewById(R.id.main_container);
-
-        ViewCompat.setOnApplyWindowInsetsListener(mainContainer, (v, windowInsets) -> {
-            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-            bottomNav.setPadding(bottomNav.getPaddingLeft(), bottomNav.getPaddingTop(), bottomNav.getPaddingRight(), insets.bottom);
-            return WindowInsetsCompat.CONSUMED;
-        });
+        // [자동화의 핵심] 이 한 줄의 코드는 BottomNavigationView의 메뉴 아이템 ID와
+        // navgraph.xml에 정의된 destination(프래그먼트)의 ID를 비교하여,
+        // 탭 클릭 시 자동으로 해당 프래그먼트로 이동시키고 탭 활성 상태를 관리해줍니다.
+        NavigationUI.setupWithNavController(bottomNav, navController);
 
 
-        bottomNav.setOnItemSelectedListener(item -> {
-            Fragment selected = null;
-            int id = item.getItemId();
-            if (id == R.id.nav_pantry) {
-                Toast.makeText(this, "냉장고 화면 (추후 구현)", Toast.LENGTH_SHORT).show();
-            } else if (id == R.id.nav_search) {
-                Toast.makeText(this, "레시피 검색 화면 (추후 구현)", Toast.LENGTH_SHORT).show();
-            } else if (id == R.id.nav_favorites) {
-                // [변경] HomeFragment와 즐겨찾기 탭의 연결을 끊었습니다.
-                // [주석 처리] selected = new HomeFragment();
-                // [추가] 즐겨찾기 프래그먼트는 나중에 별도로 추가될 예정이므로, 현재는 토스트 메시지만 띄웁니다.
-                Toast.makeText(this, "즐겨찾기 화면 (추후 구현)", Toast.LENGTH_SHORT).show();
+        // -----------------------------------------------------------------
+        // [추가된 코드] 홈 화면으로 돌아올 때 탭 활성 상태를 수동으로 초기화하는 로직
+        // -----------------------------------------------------------------
+        // Navigation Component의 '자동 연결'만으로는 해결되지 않는 미묘한 UI 문제를 처리하기 위해
+        // 화면 전환 이벤트를 직접 감지하는 리스너('개인 비서')를 추가합니다.
+        navController.addOnDestinationChangedListener((controller, destination, arguments) -> {
+            // [문제 상황] '냉장고' 탭을 눌렀다가 뒤로가기를 눌러 '홈' 화면으로 돌아오면,
+            //            화면은 홈으로 바뀌었지만 하단 탭은 여전히 '냉장고'가 선택된 상태로 남아있습니다.
+            // [해결 로직] 화면이 전환될 때마다, 새로 표시된 화면의 ID를 확인합니다.
+            if (destination.getId() == R.id.home_fragment) {
+                // 만약 새로 표시된 화면이 '홈' 프래그먼트라면,
+                // 현재 BottomNavigationView에서 선택된 아이템의 ID를 가져옵니다.
+                int selectedItemId = bottomNav.getSelectedItemId();
+
+                // 만약 선택된 아이템이 있다면 (ID가 0이 아니라면),
+                if (selectedItemId != 0) {
+                    // 메뉴에서 해당 아이템을 찾아, 체크된 상태를 '강제로' 해제합니다.
+                    // 이를 통해 홈 화면에서는 모든 탭이 비활성화된 것처럼 보이게 됩니다.
+                    bottomNav.getMenu().findItem(selectedItemId).setChecked(false);
+                }
             }
-
-            if (selected != null) {
-                getSupportFragmentManager().beginTransaction()
-                        .replace(R.id.main_container, selected)
-                        .commit();
-            }
-            return true;
         });
-
-        // [삭제] 이전에 이 위치에 있던 'bottomNav.setSelectedItemId(R.id.nav_favorites);' 코드를 삭제했습니다.
-        //      해당 코드는 MainActivity 진입 시 '즐겨찾기' 탭을 강제로 선택하는 역할을 했습니다.
-
-        // [추가] MainActivity가 처음 생성되었을 때, 기본으로 HomeFragment를 표시하는 코드입니다.
-        //      이 코드는 하단 네비게이션 탭의 '선택 상태'와는 완전히 독립적으로 동작하여,
-        //      HomeFragment(메인 UI)를 화면에 보여주면서도 하단 탭은 아무것도 선택되지 않은 상태로 만들 수 있습니다.
-        if (savedInstanceState == null) {
-            getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.main_container, new HomeFragment())
-                    .commit();
-          
-            // [추가] BottomNavigationView의 자동선택 동작을 무효화하기 위해, 메뉴에 추가한 보이지 않는 더미 아이템을 선택합니다.
-            //      이렇게 하면 시각적으로는 아무 탭도 선택되지 않은 상태가 됩니다.
-            //      (복구 방법: 만약 이 기능을 제거하고 싶다면, 이 아래 한 줄의 코드만 주석 처리하거나 삭제하면 됩니다.)
-
-            bottomNav.setSelectedItemId(R.id.nav_none);
-        }
     }
 
+    // [MVP 연동] Activity의 생명주기(Lifecycle) 이벤트를 Presenter에게 전달합니다.
     @Override
     protected void onStart() {
         super.onStart();
-        presenter.start();
+        presenter.start(); // Presenter에게 시작을 알립니다. (예: 로그인 상태 확인 등)
     }
 
+    // [MVP 연동] Activity가 소멸될 때 Presenter와의 연결을 끊어 메모리 누수를 방지합니다.
     @Override
     protected void onDestroy() {
         if (presenter != null) presenter.detach();
         super.onDestroy();
     }
 
+    // [Toolbar 메뉴 설정] 툴바에 표시될 메뉴(main_toolbar_menu.xml)를 생성합니다.
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.main_toolbar_menu, menu);
         this.optionsMenu = menu;
-
-        MenuItem profileItem = menu.findItem(R.id.action_profile);
-        if (profileItem != null) {
-            View actionView = profileItem.getActionView();
-            if (actionView != null) {
-                actionView.setOnClickListener(v -> {
-                    Toast.makeText(MainActivity.this, "프로필 화면(추후 연결)", Toast.LENGTH_SHORT).show();
-                });
-            }
-        }
         return true;
     }
 
+    // [Toolbar 메뉴 클릭 처리] 툴바의 메뉴 아이템(로그아웃 등)이 클릭되었을 때 호출됩니다.
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         int id = item.getItemId();
-        if (id == R.id.action_profile) {
-            return true;
-        } else if (id == R.id.action_logout) {
-            if (item.isEnabled()) {
-                presenter.onLogoutClicked();
-            }
+        if (id == R.id.action_logout) {
+            // 로그아웃 버튼이 클릭되면, 직접 로직을 처리하지 않고 Presenter에게 위임합니다.
+            presenter.onLogoutClicked();
             return true;
         }
         return super.onOptionsItemSelected(item);
     }
+
+
+    // =================================================================
+    // [MainContract.View 인터페이스 구현] - Presenter가 View를 제어하는 메서드들
+    // =================================================================
 
     @Override
     public void showLogoutMessage(String message) {
@@ -159,12 +165,7 @@ public class MainActivity extends AppCompatActivity implements MainContract.View
             MenuItem logoutItem = optionsMenu.findItem(R.id.action_logout);
             if (logoutItem != null) {
                 logoutItem.setEnabled(enabled);
-                android.util.Log.d("MainActivity", "setLogoutEnabled: Logout menu item " + (enabled ? "enabled" : "disabled"));
-            } else {
-                android.util.Log.w("MainActivity", "setLogoutEnabled: Logout menu item (R.id.action_logout) not found.");
             }
-        } else {
-            android.util.Log.w("MainActivity", "setLogoutEnabled: OptionsMenu is null. Cannot enable/disable logout menu item.");
         }
     }
 

--- a/app/src/main/java/com/example/food_recipe/pantry/PantryFragment.java
+++ b/app/src/main/java/com/example/food_recipe/pantry/PantryFragment.java
@@ -1,0 +1,20 @@
+package com.example.food_recipe.pantry;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import com.example.food_recipe.R;
+
+public class PantryFragment extends Fragment {
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        // fragment_pantry.xml 레이아웃을 인플레이트하여 반환합니다.
+        return inflater.inflate(R.layout.fragment_pantry, container, false);
+    }
+}

--- a/app/src/main/java/com/example/food_recipe/search/SearchFragment.java
+++ b/app/src/main/java/com/example/food_recipe/search/SearchFragment.java
@@ -1,0 +1,20 @@
+package com.example.food_recipe.search;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import com.example.food_recipe.R;
+
+public class SearchFragment extends Fragment {
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        // fragment_search.xml 레이아웃을 인플레이트하여 반환합니다.
+        return inflater.inflate(R.layout.fragment_search, container, false);
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    activity_main.xml 파일은 앱의 메인 화면 레이아웃을 정의합니다.
-    UI 요소(버튼, 텍스트, 이미지 등)를 어떻게 배치할지 결정하는 설계도와 같습니다.
--->
-
-<!--
-    <RelativeLayout> : 이 화면의 가장 바깥쪽 컨테이너(틀)입니다.
-    이름처럼, 내부에 있는 UI 요소들을 서로 '상대적인' 위치에 배치할 수 있습니다.
-    (예: 'A의 오른쪽에 B 배치', '화면 맨 아래에 C 고정' 등)
+    [최종 구조 변경] 최상위 레이아웃을 RelativeLayout으로 변경합니다.
+    이는 하단 네비게이션 바를 제외한 '콘텐츠 영역'의 크기를 명확하게 분리하여
+    내부 프래그먼트들이 정확한 공간을 할당받도록 하기 위한 가장 확실한 구조입니다.
 -->
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
@@ -15,64 +10,68 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <!-- 1. 화면 상단에 위치할 앱바(AppBar) 영역 -->
     <!--
-        <com.google.android.material.appbar.AppBarLayout> : 툴바(Toolbar)를 감싸는 컨테이너입니다.
-        스크롤과 관련된 동작이나 그림자 효과 등을 관리합니다.
-    -->
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/main_appbar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"     
-        android:fitsSystemWindows="true"        
-        android:background="@color/black_2">    
-
-        <!--
-            <com.google.android.material.appbar.MaterialToolbar> : 화면의 제목과 메뉴 등을 표시하는 툴바입니다.
-            최신 Material Design 스타일이 적용된 툴바입니다.
-        -->
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/main_toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="64dp"
-            android:theme="@style/MyToolbarTheme"           
-            app:title="Food Recipe"                         
-            app:titleTextColor="@color/white"               
-            app:navigationIconTint="@color/white"           
-            app:menu="@menu/main_toolbar_menu"             
-            app:titleTextAppearance="@style/MyToolbarTitleStyle" 
-            app:contentInsetStart="24dp" />                 
-    </com.google.android.material.appbar.AppBarLayout>
-
-    <!-- 2. 화면 하단에 위치할 네비게이션 바 -->
-    <!--
-        <com.google.android.material.bottomnavigation.BottomNavigationView> : 화면 하단에 고정되어
-        주요 메뉴(홈, 검색, 즐겨찾기 등) 간의 이동을 돕는 UI 컴포넌트입니다.
+        [변경] BottomNavigationView의 위치를 RelativeLayout의 규칙으로 제어합니다.
+        - android:layout_alignParentBottom="true" 속성은 이 뷰를 부모의 맨 아래에 고정시킵니다.
+        - 이렇게 하면 이 뷰의 공간이 다른 콘텐츠 영역과 겹치지 않고 명확하게 분리됩니다.
+        [삭제] CoordinatorLayout 내부에서 사용되던 android:layout_gravity="bottom"은 삭제합니다.
     -->
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/main_bottom_nav"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true" 
-        android:background="@color/black_2"     
-        app:itemIconTint="@color/bottom_nav_icon_tint_selector" 
-        app:itemTextColor="@color/white"                        
-        app:menu="@menu/bottom_nav_menu"                        
+        android:layout_alignParentBottom="true"
+        android:background="@color/black_2"
+        app:itemIconTint="@color/bottom_nav_icon_tint_selector"
+        app:itemTextColor="@color/white"
+        app:menu="@menu/bottom_nav_menu"
         app:itemActiveIndicatorStyle="@style/MyBottomNavActiveIndicatorStyle" />
-    <!-- 3. 메인 콘텐츠가 표시될 중앙 영역 -->
+
     <!--
-        <FrameLayout> : UI 요소를 겹겹이 쌓을 수 있는 가장 단순한 레이아웃입니다.
-        여기서는 하단 네비게이션 바의 선택에 따라 다양한 화면 조각(Fragment)들이 교체되어 보여질 공간입니다.
-        - android:layout_below="@id/appbar"       : 위에 있는 앱바(@id/appbar)의 '아래에' 위치시킵니다.
-        - android:layout_above="@id/bottom_nav"   : 아래에 있는 네비게이션 바(@id/bottom_nav)의 '위에' 위치시킵니다.
-        결과적으로 앱바와 네비게이션 바 사이의 남는 공간 전체를 차지하게 됩니다.
+        [변경] 기존의 CoordinatorLayout을 RelativeLayout의 자식으로 배치합니다.
+        [추가] android:layout_above="@+id/main_bottom_nav" 속성을 추가하여
+               이 레이아웃이 BottomNavigationView의 '바로 위' 공간 전체를 차지하도록 지정합니다.
+               이것이 프래그먼트의 중앙 정렬 문제를 해결하는 핵심입니다.
     -->
-    <FrameLayout
-        android:id="@+id/main_container"
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/main_appbar"
-        android:layout_above="@id/main_bottom_nav"/>
+        android:layout_above="@id/main_bottom_nav">
+
+        <!-- AppBarLayout과 Toolbar는 기존 구조 그대로 유지됩니다. -->
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/main_appbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fitsSystemWindows="true"
+            android:background="@color/black_2">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/main_toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="64dp"
+                android:theme="@style/MyToolbarTheme"
+                app:title="Food Recipe"
+                app:titleTextColor="@color/white"
+                app:navigationIconTint="@color/white"
+                app:menu="@menu/main_toolbar_menu"
+                app:titleTextAppearance="@style/MyToolbarTitleStyle"
+                app:contentInsetStart="24dp" />
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <!--
+            FragmentContainerView는 이제 정확한 크기의 공간(CoordinatorLayout) 내부에
+            배치되므로, 내부 프래그먼트의 중앙 정렬이 완벽하게 동작합니다.
+        -->
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/nav_host_fragment"
+            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:defaultNavHost="true"
+            app:navGraph="@navigation/navgraph"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_favorites.xml
+++ b/app/src/main/res/layout/fragment_favorites.xml
@@ -1,100 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+<!--
+    [변경] 최상위 레이아웃을 LinearLayout/NestedScrollView에서 ConstraintLayout으로 변경합니다.
+    ConstraintLayout은 복잡한 화면 구조에서 뷰의 위치를 가장 정확하고 안정적으로 제어하는 현대적인 방식입니다.
+-->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@android:color/white">
+    android:layout_height="match_parent">
 
     <!--
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="56dp"
-        android:background="#D9D9D9"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp">
+        [변경] TextView에 제약(Constraint)을 추가하여 화면의 정중앙에 위치시킵니다.
+        - 상/하/좌/우를 모두 부모(parent)에 연결하면, 마치 네 방향에서 고무줄로 당기는 것처럼
+          물리적으로 완벽한 중앙에 위치하게 됩니다.
+        - 이는 gravity 속성보다 훨씬 더 정확하고 신뢰성 높은 중앙 정렬 방식입니다.
 
-        <TextView
-            android:id="@+id/fa_tv_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
-            android:text="즐겨찾기"
-            android:textStyle="bold"
-            android:textSize="22sp" />
-
-        <TextView
-            android:id="@+id/fa_tv_profile"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_alignParentEnd="true"
-            android:layout_centerVertical="true"
-            android:gravity="center"
-            android:text="👤"
-            android:textSize="18sp" />
-    </RelativeLayout> -->
-
-    <!-- 검색 아이콘 -->
+        [삭제] 기존의 감싸고 있던 LinearLayout과 NestedScrollView는 삭제되었습니다.
+    -->
     <TextView
-        android:id="@+id/fa_tv_search_icon"
         android:layout_width="wrap_content"
-        android:layout_height="40dp"
-        android:gravity="center_vertical"
-        android:paddingStart="16dp"
-        android:textSize="18sp" />
-        <!-- android:text="🔍" -->
+        android:layout_height="wrap_content"
+        android:text="즐겨찾기"
+        android:textAppearance="?attr/textAppearanceHeadlineMedium"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
-    <!-- 레시피 리스트 -->
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/fa_rv_favorites"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1" />
-
-    <!--
-    <LinearLayout
-        android:id="@+id/bottom_bar"
-        android:layout_width="match_parent"
-        android:layout_height="56dp"
-        android:background="#D9D9D9"
-        android:orientation="horizontal">
-
-        <LinearLayout
-            android:id="@+id/btn_ingr"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="center">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="재료 입력"
-                android:textSize="13sp"/>
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/btn_find"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="center">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="레시피 찾기"
-                android:textSize="13sp"/>
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/btn_user"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="center">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="사용자"
-                android:textSize="13sp"/>
-        </LinearLayout>
-    </LinearLayout> -->
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -5,10 +5,18 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fillViewport="true"
-    android:fitsSystemWindows="true"
     android:background="?attr/colorSurface">
+    <!--
+        [삭제된 속성]
+        1. android:fitsSystemWindows="true"
+        2. app:layout_behavior="@string/appbar_scrolling_view_behavior"
 
-    <!-- 로그인 화면과 동일한 패딩/배치 -->
+        이 두 속성의 역할은 이제 activity_main.xml의 CoordinatorLayout과
+        FragmentContainerView가 담당하므로, 여기서는 반드시 삭제해야
+        속성 충돌로 인한 오류가 발생하지 않습니다.
+    -->
+
+    <!-- 내부 LinearLayout 및 모든 하위 뷰들은 변경 없이 100% 그대로 유지됩니다. -->
     <LinearLayout
         android:id="@+id/fmain_home_root"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_pantry.xml
+++ b/app/src/main/res/layout/fragment_pantry.xml
@@ -1,108 +1,30 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    [변경] 최상위 레이아웃을 LinearLayout/NestedScrollView에서 ConstraintLayout으로 변경합니다.
+    ConstraintLayout은 복잡한 화면 구조에서 뷰의 위치를 가장 정확하고 안정적으로 제어하는 현대적인 방식입니다.
+-->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@android:color/white">
+    android:layout_height="match_parent">
 
     <!--
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="56dp"
-        android:background="#D9D9D9"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp">
+        [변경] TextView에 제약(Constraint)을 추가하여 화면의 정중앙에 위치시킵니다.
+        - 상/하/좌/우를 모두 부모(parent)에 연결하면, 마치 네 방향에서 고무줄로 당기는 것처럼
+          물리적으로 완벽한 중앙에 위치하게 됩니다.
+        - 이는 gravity 속성보다 훨씬 더 정확하고 신뢰성 높은 중앙 정렬 방식입니다.
 
-        <LinearLayout
-            android:id="@+id/btn_menu"
-            android:layout_width="32dp"
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:gravity="center_vertical"
-            android:layout_alignParentStart="true"
-            android:padding="4dp">
+        [삭제] 기존의 감싸고 있던 LinearLayout과 NestedScrollView는 삭제되었습니다.
+    -->
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="냉장고"
+        android:textAppearance="?attr/textAppearanceHeadlineMedium"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="2dp"
-                android:background="#000000"
-                android:layout_marginBottom="4dp"/>
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="2dp"
-                android:background="#000000"
-                android:layout_marginBottom="4dp"/>
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="2dp"
-                android:background="#000000"/>
-        </LinearLayout>
-    </RelativeLayout> -->
-
-    <!-- 중앙 안내 메시지 (정중앙 배치) -->
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:gravity="center">
-
-        <TextView
-            android:id="@+id/pa_tv_empty_message"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="재료가 비었습니다 추가해주세요"
-            android:textSize="14sp"
-            android:textColor="#666666"/>
-    </LinearLayout>
-
-    <!-- 하단 바
-    <LinearLayout
-        android:id="@+id/bottom_bar"
-        android:layout_width="match_parent"
-        android:layout_height="56dp"
-        android:background="#D9D9D9"
-        android:orientation="horizontal">
-
-        <LinearLayout
-            android:id="@+id/btn_ingr"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="center">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="재료 입력"
-                android:textStyle="bold"
-                android:textSize="13sp"/>
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/btn_find"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="center">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="레시피 찾기"
-                android:textSize="13sp"/>
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/btn_user"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="center">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="사용자"
-                android:textSize="13sp"/>
-        </LinearLayout>
-    </LinearLayout> -->
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -1,151 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+<!--
+    [변경] 최상위 레이아웃을 LinearLayout/NestedScrollView에서 ConstraintLayout으로 변경합니다.
+    ConstraintLayout은 복잡한 화면 구조에서 뷰의 위치를 가장 정확하고 안정적으로 제어하는 현대적인 방식입니다.
+-->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@android:color/white">
+    android:layout_height="match_parent">
 
     <!--
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="56dp"
-        android:background="#D9D9D9"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp">
+        [변경] TextView에 제약(Constraint)을 추가하여 화면의 정중앙에 위치시킵니다.
+        - 상/하/좌/우를 모두 부모(parent)에 연결하면, 마치 네 방향에서 고무줄로 당기는 것처럼
+          물리적으로 완벽한 중앙에 위치하게 됩니다.
+        - 이는 gravity 속성보다 훨씬 더 정확하고 신뢰성 높은 중앙 정렬 방식입니다.
 
-        <TextView
-            android:id="@+id/tv_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
-            android:text="레시피 찾기"
-            android:textStyle="bold"
-            android:textSize="22sp" />
-
-        <TextView
-            android:id="@+id/tv_profile"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_alignParentEnd="true"
-            android:layout_centerVertical="true"
-            android:gravity="center"
-            android:text="👤"
-            android:textSize="18sp" />
-    </RelativeLayout> -->
-
-    <!-- 검색 아이콘 -->
+        [삭제] 기존의 감싸고 있던 LinearLayout과 NestedScrollView는 삭제되었습니다.
+    -->
     <TextView
-        android:id="@+id/se_tv_search_icon"
-        android:layout_width="wrap_content"
-        android:layout_height="40dp"
-        android:gravity="center_vertical"
-        android:paddingStart="16dp"
-        android:textSize="18sp" />
-        <!-- android:text="🔍" -->
-
-    <!-- 카테고리 체크박스 -->
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:background="#D9D9D9"
-        android:padding="8dp"
-        android:gravity="center_vertical">
-
-        <CheckBox
-            android:id="@+id/se_cb_korean"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="한식"
-            android:checked="true" />
-
-        <CheckBox
-            android:id="@+id/se_cb_western"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="양식"
-            android:layout_marginStart="12dp"/>
-
-        <CheckBox
-            android:id="@+id/se_cb_chinese"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="중식"
-            android:layout_marginStart="12dp"/>
-
-        <CheckBox
-            android:id="@+id/se_cb_japanese"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="일식"
-            android:layout_marginStart="12dp"/>
-    </LinearLayout>
-
-    <!-- 정렬 텍스트 -->
-    <TextView
-        android:id="@+id/se_tv_sort"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:layout_gravity="end"
-        android:text="인기순"
-        android:textSize="14sp"/>
+        android:text="레시피 검색"
+        android:textAppearance="?attr/textAppearanceHeadlineMedium"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
-    <!-- 레시피 리스트 -->
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/se_rv_recipes"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:paddingTop="4dp"
-        android:paddingBottom="4dp"/>
-
-    <!--
-    <LinearLayout
-        android:id="@+id/bottom_bar"
-        android:layout_width="match_parent"
-        android:layout_height="56dp"
-        android:background="#D9D9D9"
-        android:orientation="horizontal">
-
-        <LinearLayout
-            android:id="@+id/btn_ingr"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="center">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="재료 입력"
-                android:textSize="13sp"/>
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/btn_find"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="center">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="레시피 찾기"
-                android:textStyle="bold"
-                android:textSize="13sp"/>
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/btn_user"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="center">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="사용자"
-                android:textSize="13sp"/>
-        </LinearLayout>
-    </LinearLayout> -->
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/navgraph.xml
+++ b/app/src/main/res/navigation/navgraph.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/navgraph"
+    app:startDestination="@id/home_fragment">
+
+    <fragment
+        android:id="@+id/home_fragment"
+        android:name="com.example.food_recipe.home.HomeFragment"
+        android:label="fragment_home"
+        tools:layout="@layout/fragment_main" />
+
+    <fragment
+        android:id="@+id/nav_favorites"
+        android:name="com.example.food_recipe.favorites.FavoritesFragment"
+        android:label="fragment_favorites"
+        tools:layout="@layout/fragment_favorites" />
+
+    <fragment
+        android:id="@+id/nav_pantry"
+        android:name="com.example.food_recipe.pantry.PantryFragment"
+        android:label="fragment_pantry"
+        tools:layout="@layout/fragment_pantry" />
+
+    <fragment
+        android:id="@+id/nav_search"
+        android:name="com.example.food_recipe.search.SearchFragment"
+        android:label="fragment_search"
+        tools:layout="@layout/fragment_search" />
+
+</navigation>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
     // 'apply false'의 의미는 위와 동일하며, 모듈 수준에서 실제로 적용합니다.
     // 버전은 libs.versions.toml을 통해 관리됩니다.
     alias(libs.plugins.google.gms.google.services) apply false
+
+
     
 
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.13.0"
+coordinatorlayout = "1.3.0"
 coreSplashscreen = "1.0.1"
 junit = "4.13.2"
 junitVersion = "1.3.0"
@@ -20,6 +21,7 @@ navigationFragment = "2.9.5"
 playServicesAuth = "21.4.0"
 
 [libraries]
+coordinatorlayout = { module = "androidx.coordinatorlayout:coordinatorlayout", version.ref = "coordinatorlayout" }
 core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }


### PR DESCRIPTION
기존 방식에서 로그인,회원가입,비밀번호찾기는
기존 방식으로 유지하고

로그인후 메인 진입시
Jetpack Navigation Component
로 리팩토링해서

res 패키지 아래에 navigation 패키지
를 만들고 navgraph xml 파일을 만듬
navgraph의 역활은 (설계서) 그리고
시각적으로 지도처럼 보여줌

호스트는 NavHost 메인 레이아웃 activity_main

컨트롤러 는 MainActivity.java  (View)
대상 간 탐색, 딥 링크 처리, 백 스택 관리 등의 작업을 등 을함

목적지 는 NavHost 에 <fragment> 태그로
설정되어있음

경로는 현재 정의되지않음

이유 하단네비게이션 프레그먼트는 화살표로 연결할 필요가 없어서

나중에 홈프레그먼트 -> 레시피 상세화면
이동의 경우 경로 설정을 해야함 만들경우

현재는 기존 레이아웃 디자인에서 냉장고 레이아웃, 레시피 검색 레이아웃, 즐겨찾기 레이아웃 을 화면전환 잘되는지 알아보려고 간단하게 짰음

추후에 기존에 레이아웃짠 디자인대로 변경해야함 

그리고 하단 네비게이션바 고정된 3탭 냉장고 , 레시피검색 , 즐겨찾기
화면전환이 이루어지며 (하단네비게이션 클릭시 표시되는 동그라미) 활성표시자도
정상적으로 작동하게함